### PR TITLE
Update alloy.vim - add alloyAttribute, alloyBrackets, alloyParentheses, alloyPeriod, and alloyOperator

### DIFF
--- a/syntax/alloy.vim
+++ b/syntax/alloy.vim
@@ -10,7 +10,30 @@ syn keyword alloyConstant           true false null
 syn region alloyComment start=/\/\// end=/$/    contains=alloyTodo
 syn region alloyComment start=/\/\*/ end=/\*\// contains=alloyTodo
 
-syn region alloyString start=/"/ end=/"/ contains=alloyEscape
+syn region alloyString start=/"/ end=/"/ contains=alloyEscape,alloyPeriod,alloyQuotes
+
+"syn match alloyQuotes '"' contained
+
+" opening brace
+syn match alloyBlockBrace "{"
+" closing brace
+syn match alloyBlockBrace "}"
+
+" add folding on blocks
+syn region alloyBlock start="{" end="}" transparent fold
+
+" closing bracket
+syn match alloyBrackets "]"
+" opening bracket
+syn match alloyBrackets "\["
+
+" closing paren
+syn match alloyParentheses ")"
+" opening paren
+syn match alloyParentheses "("
+
+" match periods
+syn match alloyPeriod "\."
 
 syn match alloyEscape display contained "\\[0-7]\{3}"
 syn match alloyEscape display contained +\\[abfnrtv\\'"]+
@@ -23,9 +46,18 @@ syn match alloyInt   "\<-\=\(0\|[1-9]_\?\(\d\|\d\+_\?\d\+\)*\)\%([Ee][-+]\=\d\+\
 syn match alloyFloat "\<-\=\d\+\.\d*\%([Ee][-+]\=\d\+\)\=\>"
 syn match alloyFloat "\<-\=\.\d\+\%([Ee][-+]\=\d\+\)\=\>"
 
-syn match  alloyBlockHeader /^[^=]\+{/ contains=alloyBlockName,alloyBlockLabel,alloyComment
+" all equal signs, plush signs, and commas
+syn match alloyOperator "="
+syn match alloyOperator "\v\+"
+syn match alloyOperator ","
+
+syn match  alloyBlockHeader /^[^=]\+{/ contains=alloyBlockName,alloyBlockLabel,alloyComment,alloyBlockBrace
+
 syn match  alloyBlockName   /^\s*\([A-Za-z_][A-Za-z0-9_]*\)\(\.\([A-Za-z_][A-Za-z0-9_]*\)\)*/ skipwhite contained
 syn region alloyBlockLabel  start=/"/ end=/"/ contained
+
+" attempt to match left side of equalsign inside the block
+syn match alloyAttribute /^.\{-}=/ contains=alloyComment,alloyOperator
 
 hi def link alloyBlockName  Structure
 hi def link alloyBlockLabel String


### PR DESCRIPTION
Hoi!

Thanks for this plugin, it was very helpful! I've added a number of little syntax matches such as:
- `alloyBlockBrace`
- `alloyParentheses`
- `alloyBrackets`
- `alloyOperator`
- `alloyPeriod`
- `alloyAttribute`

There is also an attempt for `alloyQuotes`, but it is commented out, because I can't figure out how to make it work, but maybe someone else can 🤷 

Finally, I attempted to add a fold on blocks (using `alloyBlockBrace`), but couldn't get it work either. Everything else is tested and working though.

<img width="450" height="245" alt="syntax highlighting example showing all the above syntax matches highlighted using the spacechalk theme" src="https://github.com/user-attachments/assets/87eb3d3e-65ec-48d3-80f0-582ad67fc28a" />

I use [spacechalk.nvim](https://github.com/space-chalk/spacechalk.nvim) for my theme, but here's the highlights I used there for the above screenshot if anyone is curious:

```vim
hi def link alloyString     String
hi def link alloyEscape     Special
hi def link alloyInt        Number
hi def link alloyFloat      Number
hi def link alloyConstant   Constant
hi def link alloyComment    Comment
hi def link alloyTodo       Todo

highlight alloyBlockName    guifg=#6DF2E5 guibg=#323232
highlight alloyBlockLabel   guifg=#C1FF87 cterm=italic gui=italic
highlight alloyBlockBrace   guifg=#f289f9
highlight alloyParentheses  guifg=#7aa2f7
highlight alloyBrackets     guifg=#ff8d87
highlight alloyOperator     guifg=#f7fb53
highlight alloyPeriod       guifg=#d092fc
highlight alloyAttribute    guifg=#5cc9fd
```

If this repo is inactive, and a community member finds this, please feel free to come and contribute back to [jessebot/vim-alloy](https://codeberg.org/jessebot/vim-alloy) or [jessebot/vim-alloy](https://git.smallhack.org/jessebot/vim-alloy)  💙 ✨ 